### PR TITLE
Revert "Update dependency org.apache.httpcomponents.client5:httpclient5 to v5.2.2"

### DIFF
--- a/crt-sh-client/pom.xml
+++ b/crt-sh-client/pom.xml
@@ -100,7 +100,7 @@
 		<dependency>
 			<groupId>org.apache.httpcomponents.client5</groupId>
 			<artifactId>httpclient5</artifactId>
-			<version>5.2.2</version>
+			<version>5.2.1</version>
 		</dependency>
 
 		<!-- JSON processing: jackson -->


### PR DESCRIPTION
Reverts litetex/crt-sh-client#1

Reason: Serious bug:
https://issues.apache.org/jira/browse/HTTPCLIENT-2292 / https://github.com/apache/httpcomponents-client/commit/6d60624cd3439f81030f7443e72cba21662e5d7b